### PR TITLE
ComfyUI Fixes

### DIFF
--- a/kubernetes/services/comfyui/values.yaml
+++ b/kubernetes/services/comfyui/values.yaml
@@ -33,8 +33,8 @@ controllers:
           value: "--verbose=DEBUG"
         resources:
           limits:
-            cpu: 1
-            memory: 6Gi
+            cpu: 8
+            memory: 20Gi
             nvidia.com/gpu: "1"
           requests:
             cpu: 250m

--- a/kubernetes/services/comfyui/values.yaml
+++ b/kubernetes/services/comfyui/values.yaml
@@ -23,7 +23,7 @@ controllers:
         image:
           repository: harbor.cloud.danmanners.com/library/danmanners/comfyui
           tag: v0.3.45
-          pullPolicy: "IfNotPresent"
+          pullPolicy: Always
         env:
         - name: NVIDIA_VISIBLE_DEVICES
           value: all

--- a/kubernetes/services/comfyui/values.yaml
+++ b/kubernetes/services/comfyui/values.yaml
@@ -58,16 +58,6 @@ service:
         protocol: TCP
 
 persistence:
-  data:
-    enabled: true
-    type: persistentVolumeClaim
-    storageClass: ceph-rbd-retain
-    accessMode: ReadWriteOnce
-    size: 10Gi
-    retain: true
-    globalMounts:
-    - path: /root
-      readOnly: false
   home:
     enabled: true
     type: persistentVolumeClaim

--- a/kubernetes/services/comfyui/values.yaml
+++ b/kubernetes/services/comfyui/values.yaml
@@ -18,11 +18,11 @@ controllers:
       core:
         ports:
         - name: http
-          containerPort: &port 8188
+          containerPort: &port 8848
           protocol: TCP
         image:
-          repository: docker.io/yanwk/comfyui-boot
-          tag: "cu124-slim"
+          repository: harbor.cloud.danmanners.com/library/danmanners/comfyui
+          tag: v0.3.45
           pullPolicy: "IfNotPresent"
         env:
         - name: NVIDIA_VISIBLE_DEVICES

--- a/kubernetes/services/comfyui/values.yaml
+++ b/kubernetes/services/comfyui/values.yaml
@@ -73,8 +73,8 @@ persistence:
     type: persistentVolumeClaim
     storageClass: ceph-rbd-retain
     accessMode: ReadWriteOnce
-    size: 100Gi
+    size: 200Gi
     retain: true
     globalMounts:
-    - path: /home/runner
+    - path: /app/ComfyUI/models/
       readOnly: false

--- a/kubernetes/services/comfyui/values.yaml
+++ b/kubernetes/services/comfyui/values.yaml
@@ -18,7 +18,7 @@ controllers:
       core:
         ports:
         - name: http
-          containerPort: &port 8848
+          containerPort: &port 8188
           protocol: TCP
         image:
           repository: harbor.cloud.danmanners.com/library/danmanners/comfyui


### PR DESCRIPTION
This pull request updates the configuration of the `comfyui` service in the `kubernetes/services/comfyui/values.yaml` file. The changes focus on updating the container image, increasing resource allocation, and modifying persistence settings.

### Image and Deployment Configuration Updates:
* Updated the container image repository to `harbor.cloud.danmanners.com/library/danmanners/comfyui`, changed the tag to `v0.3.45`, and set the pull policy to `Always`. This ensures the deployment uses the latest image from the new repository.

### Resource Allocation Changes:
* Increased CPU limits from `1` to `8` and memory limits from `6Gi` to `20Gi` to support higher workloads.

### Persistence Configuration Updates:
* Removed the `data` persistence configuration entirely, including its associated storage class and global mounts.
* Updated the `home` persistence configuration by increasing the storage size from `100Gi` to `200Gi` and changing the global mount path from `/home/runner` to `/app/ComfyUI/models/`, reflecting a more specific use case for storage.