### PR TITLE
feat(fission): deploy Fission v1.27.0 with Gateway API routing via shared gwapi

### DIFF
--- a/kubernetes/applications/fission.yaml
+++ b/kubernetes/applications/fission.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: fission
+  namespace: argocd
+  labels:
+    chartVersion: &chartVersion 1.27.0
+spec:
+  destination:
+    namespace: fission
+    server: https://kubernetes.default.svc
+  project: default
+  sources:
+    - repoURL: &repo https://github.com/GoodMannersHosting/home-enterprise-labops.git
+      targetRevision: main
+      path: kubernetes/services/fission
+    - repoURL: *repo
+      targetRevision: main
+      ref: values
+    - repoURL: https://fission.github.io/fission-charts
+      chart: fission-all
+      targetRevision: *chartVersion
+      helm:
+        valueFiles:
+          - $values/kubernetes/services/fission/values.yaml
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=true

--- a/kubernetes/services/fission/kustomization.yaml
+++ b/kubernetes/services/fission/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+namespace: fission
+resources:
+  - namespace.yaml
+  # Fission v1.27.0 CRDs; shipped separately from the fission-all chart.
+  # Keep the ref in sync with chartVersion in kubernetes/applications/fission.yaml.
+  - github.com/fission/fission/crds/v1?ref=v1.27.0

--- a/kubernetes/services/fission/namespace.yaml
+++ b/kubernetes/services/fission/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fission

--- a/kubernetes/services/fission/values.yaml
+++ b/kubernetes/services/fission/values.yaml
@@ -1,0 +1,18 @@
+---
+# Fission serverless platform (https://github.com/fission/fission).
+#
+# Functions are exposed via the shared Cilium Gateway (gwapi, 172.31.0.10):
+# the router generates an HTTPRoute per trigger under
+# functions.cloud.danmanners.com when a trigger uses
+# `--route-provider gateway` (gatewayAPI.enabled below).
+gatewayAPI:
+  enabled: true
+  # Shared cluster Gateway — kubernetes/core/gateway-api/gateway.yaml.
+  defaultParentRef: default/gwapi
+
+# Public traffic enters through the Gateway above; no LoadBalancer for the
+# router service (chart default is LoadBalancer).
+routerServiceType: ClusterIP
+
+# Namespace where functions/environments/triggers are created by default.
+defaultNamespace: default


### PR DESCRIPTION
# Add Fission (v1.27.0) — serverless functions via the shared Gateway

Deploys [Fission](https://github.com/fission/fission) **v1.27.0** (latest stable, released 2026-06-22; requires K8s >= 1.32, cluster is 1.36.1) using the official `fission-charts/fission-all` Helm chart via the standard ArgoCD app-of-apps flow.

## Changes

| File | Purpose |
|---|---|
| `kubernetes/applications/fission.yaml` | ArgoCD Application (auto-discovered by app-of-apps), multi-source: repo kustomization + repo values + `fission-all` chart @ 1.27.0 |
| `kubernetes/services/fission/namespace.yaml` | `fission` namespace (wildcard TLS secret auto-reflects here via emberstack reflector) |
| `kubernetes/services/fission/kustomization.yaml` | Namespace + CRDs from `fission/fission/crds/v1` pinned at `v1.27.0` (CRDs are shipped separately from the chart) |
| `kubernetes/services/fission/values.yaml` | Chart values (below) |

## Key settings

- **`gatewayAPI.enabled: true`** — enables the router's Gateway API route provider (available since v1.26.0). In this mode Fission runs in "attach mode": it generates one `HTTPRoute` per trigger (in the `fission` namespace, backend = `router` Service port 80) and attaches it to an operator-owned Gateway. It never creates/owns Gateways.
- **`gatewayAPI.defaultParentRef: default/gwapi`** — triggers that don't name a Gateway attach to our shared Cilium Gateway (`kubernetes/core/gateway-api/gateway.yaml`, LB 172.31.0.10). Its `http-cloud`/`https-cloud` listeners already match `*.cloud.danmanners.com` and allow routes from all namespaces, so **no changes to the existing gateway/LB are needed**.
- **`routerServiceType: ClusterIP`** — overrides the chart default (`LoadBalancer`); all public traffic enters through the shared Gateway.

## Usage

Functions will be served at `functions.cloud.danmanners.com` (covered by the existing `*.cloud.danmanners.com` wildcard cert on the shared Gateway):

```bash
# install CLI v1.27.0, then:
fission env create --name nodejs --image ghcr.io/fission/node-env
fission function create --name hello --env nodejs --code hello.js

# expose through the shared gateway:
fission route create --name hello --function hello --url /hello \
  --route-provider gateway \
  --route-host functions.cloud.danmanners.com
```

Then: `curl https://functions.cloud.danmanners.com/hello`

## DNS

`functions.cloud.danmanners.com` -> shared gateway LB (172.31.0.10). external-dns's `gateway-httproute` source will create it automatically once a trigger's generated HTTPRoute carries `--route-annotation external-dns.alpha.kubernetes.io/hostname=functions.cloud.danmanners.com`; alternatively add the A record in PowerDNS.

## Verification (after merge)

```bash
kubectl get pods -n fission                 # all Running
fission version                            # client/server v1.27.0
fission check                              # all services healthy
kubectl get httproute -n fission           # router-generated routes
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds Fission v1.27.0 to the Argo CD app-of-apps deployment and connects its generated HTTPRoutes to the existing shared Gateway.

- Adds a multi-source Argo CD Application using the Fission chart, repository values, and separately pinned CRDs.
- Creates the `fission` namespace and installs the v1.27.0 CRDs through Kustomize.
- Enables Fission's Gateway API provider, selects `default/gwapi`, and keeps the router Service internal with `ClusterIP`.
- Configures `default` as the default namespace for function resources.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defect identified.

The new Application follows the repository's app-of-apps and multi-source deployment patterns, while the shared Gateway's hostname and cross-namespace route policy support the configured Fission HTTPRoute attachment.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| kubernetes/applications/fission.yaml | Adds the auto-discovered multi-source Argo CD Application combining repository resources, repository-hosted values, and the pinned Fission Helm chart. |
| kubernetes/services/fission/kustomization.yaml | Installs the namespace and separately pinned Fission v1.27.0 CRDs through a remote Kustomize resource. |
| kubernetes/services/fission/namespace.yaml | Declares the namespace used for the Fission control-plane deployment. |
| kubernetes/services/fission/values.yaml | Enables Gateway API integration with the shared Gateway, changes the router to ClusterIP, and configures the default function namespace. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Argo[Argo CD app-of-apps] --> App[Fission Application]
    App --> CRDs[Kustomize: namespace and CRDs]
    App --> Chart[Helm: fission-all 1.27.0]
    Client[HTTPS client] --> Gateway[Shared Cilium Gateway default/gwapi]
    Trigger[Fission HTTP trigger] --> Route[Generated HTTPRoute in fission]
    Route --> Gateway
    Gateway --> Router[Router Service port 80]
    Router --> Function[Fission function]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(fission): deploy Fission v1.27.0 wi..."](https://github.com/goodmannershosting/home-enterprise-labops/commit/bb507ae05791731225735733c25613d51709383c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56261950)</sub>

<!-- /greptile_comment -->